### PR TITLE
Align conversations API with OpenAI Conversations spec + Databricks design

### DIFF
--- a/agent_plane/db/db_models.py
+++ b/agent_plane/db/db_models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from sqlalchemy import (
+    JSON,
     Boolean,
     CheckConstraint,
     ForeignKey,
@@ -95,6 +96,10 @@ class SqlConversation(Base):
         last updated (item append, title change, etc.).
     :param title: Optional human-readable title for the conversation.
         ``None`` when not provided.
+    :param metadata_: Optional key-value metadata map (up to 16 pairs,
+        keys ≤64 chars, values ≤512 chars). Stored in the ``metadata``
+        column. Attribute uses trailing underscore to avoid shadowing
+        :attr:`DeclarativeBase.metadata`. ``None`` when not provided.
     :param kind: Conversation type. ``"default"`` for user-initiated,
         ``"sub_agent"`` for sub-agent execution conversations.
     :param parent_conversation_id: For Phase 4 named sub-agents,
@@ -109,6 +114,9 @@ class SqlConversation(Base):
     created_at: Mapped[int] = mapped_column(Integer)
     updated_at: Mapped[int] = mapped_column(Integer)
     title: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Stored as "metadata" column; attribute uses trailing underscore to
+    # avoid shadowing DeclarativeBase.metadata (a SQLAlchemy reserved name).
+    metadata_: Mapped[dict[str, str] | None] = mapped_column("metadata", JSON, nullable=True)
     kind: Mapped[str] = mapped_column(String(32), default="default")
     parent_conversation_id: Mapped[str | None] = mapped_column(
         String(64),

--- a/agent_plane/db/migrations/versions/8a3f9c2d1e4b_add_metadata_to_conversations.py
+++ b/agent_plane/db/migrations/versions/8a3f9c2d1e4b_add_metadata_to_conversations.py
@@ -1,0 +1,29 @@
+"""add metadata column to conversations
+
+Revision ID: 8a3f9c2d1e4b
+Revises: 43fb65b29464
+Create Date: 2026-04-20 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "8a3f9c2d1e4b"
+down_revision: str | None = "43fb65b29464"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "conversations",
+        sa.Column("metadata", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("conversations", "metadata")

--- a/agent_plane/entities/conversation.py
+++ b/agent_plane/entities/conversation.py
@@ -24,6 +24,9 @@ class Conversation:
         sub-agents store ``"<type>:<name>"`` here so the partial
         unique index on ``(parent_conversation_id, title)`` can
         enforce uniqueness within a parent.
+    :param metadata: Optional key-value map of up to 16 pairs
+        (keys ≤64 chars, values ≤512 chars). Set by the client
+        at create or update time.
     :param kind: Conversation type. ``"default"`` for
         user-initiated, ``"sub_agent"`` for sub-agent
         execution conversations.
@@ -36,6 +39,7 @@ class Conversation:
     created_at: int
     updated_at: int
     title: str | None = None
+    metadata: dict[str, str] | None = None
     kind: str = "default"
     parent_conversation_id: str | None = None
 

--- a/agent_plane/server/API.md
+++ b/agent_plane/server/API.md
@@ -8,7 +8,7 @@ and files (`/v1/files`).
 | Namespace | Compatible with | Reference implementation |
 |---|---|---|
 | Agent Management (`/api/agents`) | Agent Plane (ours) | No external reference — this is our own API. |
-| Conversations (`/v1/conversations`) | Agent Plane (ours) | No external reference. OpenResponses defines a minimal `conversation` object on responses but no conversation management endpoints. |
+| Conversations (`/v1/conversations`) | [OpenAI Conversations API](https://platform.openai.com/docs/api-reference/conversations) | OpenAI's Conversations API is the reference. Agent-plane extends it with `title` and cursor-based pagination. Update uses `PATCH` (REST-style) as primary; `POST /{id}` accepted as alias for OpenAI SDK compat. |
 | Inference (`/v1/responses`) | [OpenResponses spec](https://openresponses.org) | OpenAI Responses API is the reference implementation. Test with: `curl https://api.openai.com/v1/responses -H "Authorization: Bearer $KEY" ...` |
 | Cancel Response (`POST /v1/responses/{id}/cancel`) | OpenAI (undocumented) | Not in OpenResponses spec. Discovered empirically on OpenAI. Test with: `curl -X POST https://api.openai.com/v1/responses/{id}/cancel -H "Authorization: Bearer $KEY"` |
 | Files (`/v1/files`) | OpenAI Files API | Test with: `curl https://api.openai.com/v1/files -H "Authorization: Bearer $KEY"` |
@@ -207,9 +207,10 @@ Content-Type: <original media type>
 
 ## Conversations
 
-Conversations are created automatically. When a response has no `previous_response_id`,
-the server creates a new conversation and assigns the response to it. When a response
-has a `previous_response_id` pointing to the **latest** response in a conversation,
+Conversations can be created explicitly via `POST /v1/conversations` or implicitly
+by the server. When a response has no `previous_response_id`, the server creates
+a new conversation and assigns the response to it. When a response has a
+`previous_response_id` pointing to the **latest** response in a conversation,
 it joins that conversation.
 
 When `previous_response_id` points to a **non-latest** response (a fork), the server
@@ -223,6 +224,52 @@ Clients may optionally pass a conversation ID when creating responses (must be
 paired with `previous_response_id`). Conversation APIs are primarily for
 **retrieval** — listing past conversations, loading message history, and finding
 the latest response ID to continue from.
+
+### Conversation object
+
+```json
+{
+  "id": "conv_abc123",
+  "object": "conversation",
+  "title": null,
+  "metadata": {"app": "my-app", "session": "s_001"},
+  "created_at": 1774118382,
+  "updated_at": 1774118400
+}
+```
+
+Fields:
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | string | Server-assigned. Format: `conv_*`. |
+| `object` | string | Always `"conversation"`. |
+| `title` | string \| null | Optional human-readable title. Agent-plane extension (not in OpenAI spec). |
+| `metadata` | object \| null | Up to 16 key-value pairs. Keys ≤64 chars, values ≤512 chars. |
+| `created_at` | integer | Unix epoch seconds. |
+| `updated_at` | integer | Unix epoch seconds of last modification. |
+
+### Create Conversation
+
+```
+POST /v1/conversations
+Content-Type: application/json
+
+{"metadata": {"app": "my-app"}}
+
+201 Created
+{
+  "id": "conv_abc123",
+  "object": "conversation",
+  "title": null,
+  "metadata": {"app": "my-app"},
+  "created_at": 1774118382,
+  "updated_at": 1774118382
+}
+```
+
+Creates an empty conversation. Items are added by subsequent `POST /v1/responses`
+calls targeting this conversation. `metadata` is optional.
 
 ### List Conversations
 
@@ -249,8 +296,8 @@ Query parameters:
 {
   "object": "list",
   "data": [
-    {"id": "conv_abc123", "object": "conversation", "title": null, "created_at": ..., "updated_at": ...},
-    {"id": "conv_def456", "object": "conversation", "title": "Weather chat", "created_at": ..., "updated_at": ...}
+    {"id": "conv_abc123", "object": "conversation", "title": null, "metadata": null, "created_at": ..., "updated_at": ...},
+    {"id": "conv_def456", "object": "conversation", "title": "Weather chat", "metadata": {"app": "x"}, "created_at": ..., "updated_at": ...}
   ],
   "first_id": "conv_abc123",
   "last_id": "conv_def456",
@@ -270,6 +317,7 @@ GET /v1/conversations/{id}
   "id": "conv_abc123",
   "object": "conversation",
   "title": null,
+  "metadata": null,
   "created_at": 1774118382,
   "updated_at": 1774118400
 }
@@ -328,19 +376,46 @@ the agent. User messages and function call outputs do not have `model` — the a
 is always recoverable from `response_id` if needed. To continue a conversation,
 pass the `response_id` from the last item as `previous_response_id`.
 
-### Update Conversation
+### Get Conversation Item
 
 ```
-PATCH /v1/conversations/{id}
+GET /v1/conversations/{id}/items/{item_id}
+
+200 OK
+{"id": "msg_aaa", "response_id": "resp_001", "type": "message", "role": "user",
+ "status": "completed", "content": [...]}
+
+404 Not Found — conversation or item not found
+```
+
+### Delete Conversation Item
+
+```
+DELETE /v1/conversations/{id}/items/{item_id}
+
+200 OK
+{"id": "msg_aaa", "object": "conversation.item.deleted", "deleted": true, "conversation_id": "conv_abc123"}
+
+404 Not Found — conversation or item not found
+```
+
+### Update Conversation
+
+Two methods are accepted; both are equivalent:
+
+```
+PATCH /v1/conversations/{id}      ← REST-style (preferred)
+POST  /v1/conversations/{id}      ← OpenAI API-style alias
 Content-Type: application/json
 
-{"title": "Weather chat"}
+{"title": "Weather chat", "metadata": {"key": "value"}}
 
 200 OK
 {
   "id": "conv_abc123",
   "object": "conversation",
   "title": "Weather chat",
+  "metadata": {"key": "value"},
   "created_at": 1774118382,
   "updated_at": 1774118400
 }
@@ -349,7 +424,8 @@ Content-Type: application/json
 400 Bad Request — invalid field
 ```
 
-Currently only `title` (string | null) is updatable.
+Updatable fields: `title` (string | null) and `metadata` (object | null).
+Any field set to `null` or omitted is left unchanged. To clear metadata, set it to `{}`.
 
 ### Delete Conversation
 
@@ -379,21 +455,32 @@ responses in the conversation before deleting.
    → POST /v1/responses {model: "my-agent", input: "...", previous_response_id: "resp_xyz"}
    → response is automatically added to the same conversation
 
-4. User starts a brand new chat
+4. User starts a brand new chat (implicit — no conversation management needed)
    → POST /v1/responses {model: "my-agent", input: "..."}
    → no previous_response_id, so server creates a new conversation
 
-5. User clicks "regenerate" on the last response
+5. User starts a new chat with app-level metadata (explicit)
+   → POST /v1/conversations {"metadata": {"app_id": "my-app", "user": "u_123"}}
+   → POST /v1/responses {model: "my-agent", input: "...", conversation: {"id": "conv_abc123"}}
+
+6. User clicks "regenerate" on the last response
    → POST /v1/responses/{id}/cancel           → stop and preserve the response
    → POST /v1/responses {model: "my-agent", input: "...", previous_response_id: "resp_prev"}
    → same previous_response_id as the cancelled response used, creating a fork
    → new conversation is created with copied history + the new response
 
-6. User steers a running agent
+7. User steers a running agent
    → POST /v1/responses {model: "my-agent", input: "Focus on X instead",
        previous_response_id: "resp_in_progress"}
    → input delivered to running agent's inbox; no new response created
 ```
+
+### Compatibility note
+
+The [OpenAI Conversations API](https://platform.openai.com/docs/api-reference/conversations)
+uses `POST /conversations/{id}` (not PATCH) for updates, and exposes `metadata` but
+not `title`. Agent-plane supports both update methods and both fields so that clients
+targeting either API surface work without modification.
 
 ---
 

--- a/agent_plane/server/routes/conversations.py
+++ b/agent_plane/server/routes/conversations.py
@@ -12,20 +12,36 @@ from agent_plane.errors import AgentPlaneError, ErrorCode
 from agent_plane.server.schemas import (
     ConversationDeleted,
     ConversationObject,
+    ItemDeleted,
     PaginatedList,
 )
 from agent_plane.stores import ConversationStore, TaskStore
 
 
+class CreateConversationRequest(BaseModel):
+    """
+    Request body for ``POST /v1/conversations``.
+
+    :param metadata: Optional key-value map of up to 16 pairs
+        (keys ≤64 chars, values ≤512 chars).
+    """
+
+    metadata: dict[str, str] | None = None
+
+
 class UpdateConversationRequest(BaseModel):
     """
-    Request body for ``PATCH /v1/conversations/{conversation_id}``.
+    Request body for ``PATCH /v1/conversations/{conversation_id}``
+    and ``POST /v1/conversations/{conversation_id}``.
 
     :param title: New title for the conversation, or ``None`` to
         leave unchanged.
+    :param metadata: New metadata map to replace the existing one,
+        or ``None`` to leave unchanged.
     """
 
     title: str | None = None
+    metadata: dict[str, str] | None = None
 
 
 def _to_conversation_object(conv: Conversation) -> ConversationObject:
@@ -39,6 +55,7 @@ def _to_conversation_object(conv: Conversation) -> ConversationObject:
     return ConversationObject(
         id=conv.id,
         title=conv.title,
+        metadata=conv.metadata,
         created_at=conv.created_at,
         updated_at=conv.updated_at,
     )
@@ -88,6 +105,25 @@ def create_conversations_router(
         ``/conversations`` endpoints.
     """
     router = APIRouter()
+
+    # ── POST /conversations ───────────────────────────────────────
+
+    @router.post("/conversations", status_code=201)
+    async def create_conversation(
+        body: CreateConversationRequest,
+    ) -> ConversationObject:
+        """
+        Explicitly create a new conversation.
+
+        The conversation is empty on creation; items are added
+        by subsequent ``POST /v1/responses`` calls or via
+        ``POST /v1/conversations/{id}/items``.
+
+        :param body: Optional metadata to attach.
+        :returns: The newly created :class:`ConversationObject`.
+        """
+        conv = conversation_store.create_conversation(metadata=body.metadata)
+        return _to_conversation_object(conv)
 
     # ── GET /conversations ────────────────────────────────────────
 
@@ -193,26 +229,114 @@ def create_conversations_router(
             has_more=page.has_more,
         )
 
-    # ── PATCH /conversations/{conversation_id} ────────────────────
+    # ── GET /conversations/{conversation_id}/items/{item_id} ─────
 
-    @router.patch("/conversations/{conversation_id}")
-    async def update_conversation(
+    @router.get("/conversations/{conversation_id}/items/{item_id}")
+    async def get_conversation_item(
+        conversation_id: str,
+        item_id: str,
+    ) -> dict[str, Any]:
+        """
+        Retrieve a single item from a conversation.
+
+        :param conversation_id: The conversation identifier,
+            e.g. ``"conv_abc123"``.
+        :param item_id: The item identifier,
+            e.g. ``"msg_abc123"``.
+        :returns: The conversation item as a flat dict.
+        :raises AgentPlaneError: If the conversation or item is
+            not found.
+        """
+        conv = conversation_store.get_conversation(conversation_id)
+        if conv is None:
+            raise AgentPlaneError("Conversation not found", code=ErrorCode.NOT_FOUND)
+        item = conversation_store.get_item(conversation_id, item_id)
+        if item is None:
+            raise AgentPlaneError("Item not found", code=ErrorCode.NOT_FOUND)
+        return _to_api_item(item)
+
+    # ── DELETE /conversations/{conversation_id}/items/{item_id} ──
+
+    @router.delete("/conversations/{conversation_id}/items/{item_id}")
+    async def delete_conversation_item(
+        conversation_id: str,
+        item_id: str,
+    ) -> ItemDeleted:
+        """
+        Delete a single item from a conversation.
+
+        :param conversation_id: The conversation identifier,
+            e.g. ``"conv_abc123"``.
+        :param item_id: The item identifier to delete,
+            e.g. ``"msg_abc123"``.
+        :returns: An :class:`ItemDeleted` confirmation.
+        :raises AgentPlaneError: If the conversation or item is
+            not found.
+        """
+        conv = conversation_store.get_conversation(conversation_id)
+        if conv is None:
+            raise AgentPlaneError("Conversation not found", code=ErrorCode.NOT_FOUND)
+        deleted = conversation_store.delete_item(conversation_id, item_id)
+        if not deleted:
+            raise AgentPlaneError("Item not found", code=ErrorCode.NOT_FOUND)
+        return ItemDeleted(id=item_id, conversation_id=conversation_id)
+
+    # ── PATCH /conversations/{conversation_id} ────────────────────
+    # ── POST  /conversations/{conversation_id} (OpenAI compat) ───
+
+    async def _do_update_conversation(
         conversation_id: str, body: UpdateConversationRequest
     ) -> ConversationObject:
         """
-        Update a conversation's mutable fields.
+        Shared update logic for PATCH and POST update handlers.
 
         :param conversation_id: The conversation identifier,
             e.g. ``"conv_abc123"``.
         :param body: Request body with fields to update.
         :returns: The updated :class:`ConversationObject`.
-        :raises AgentPlaneError: If the conversation is not
-            found.
+        :raises AgentPlaneError: If the conversation is not found.
         """
-        conv = conversation_store.update_conversation(conversation_id, title=body.title)
+        conv = conversation_store.update_conversation(
+            conversation_id, title=body.title, metadata=body.metadata
+        )
         if conv is None:
             raise AgentPlaneError("Conversation not found", code=ErrorCode.NOT_FOUND)
         return _to_conversation_object(conv)
+
+    @router.patch("/conversations/{conversation_id}")
+    async def patch_conversation(
+        conversation_id: str, body: UpdateConversationRequest
+    ) -> ConversationObject:
+        """
+        Update a conversation's mutable fields (REST-style PATCH).
+
+        :param conversation_id: The conversation identifier,
+            e.g. ``"conv_abc123"``.
+        :param body: Request body with fields to update.
+        :returns: The updated :class:`ConversationObject`.
+        :raises AgentPlaneError: If the conversation is not found.
+        """
+        return await _do_update_conversation(conversation_id, body)
+
+    @router.post("/conversations/{conversation_id}")
+    async def post_update_conversation(
+        conversation_id: str, body: UpdateConversationRequest
+    ) -> ConversationObject:
+        """
+        Update a conversation's mutable fields (OpenAI-compat POST).
+
+        The OpenAI Conversations API uses ``POST /{id}`` rather
+        than ``PATCH /{id}`` for updates. This endpoint is an
+        alias so clients targeting the OpenAI spec work without
+        modification.
+
+        :param conversation_id: The conversation identifier,
+            e.g. ``"conv_abc123"``.
+        :param body: Request body with fields to update.
+        :returns: The updated :class:`ConversationObject`.
+        :raises AgentPlaneError: If the conversation is not found.
+        """
+        return await _do_update_conversation(conversation_id, body)
 
     # ── DELETE /conversations/{conversation_id} ───────────────────
 

--- a/agent_plane/server/schemas.py
+++ b/agent_plane/server/schemas.py
@@ -126,6 +126,9 @@ class ConversationObject(BaseModel):
     :param object: Fixed resource type, always
         ``"conversation"``.
     :param title: Optional user-assigned conversation title.
+        Agent-plane extension; not present in the OpenAI spec.
+    :param metadata: Optional key-value map of up to 16 pairs
+        (keys ≤64 chars, values ≤512 chars).
     :param created_at: Unix epoch timestamp of creation.
     :param updated_at: Unix epoch timestamp of the last
         update, e.g. ``1774118400``.
@@ -134,6 +137,7 @@ class ConversationObject(BaseModel):
     id: str
     object: str = "conversation"
     title: str | None = None
+    metadata: dict[str, str] | None = None
     created_at: int
     updated_at: int
 
@@ -152,6 +156,24 @@ class ConversationDeleted(BaseModel):
     id: str
     object: str = "conversation.deleted"
     deleted: bool = True
+
+
+class ItemDeleted(BaseModel):
+    """
+    Confirmation payload returned after deleting a conversation item.
+
+    :param id: ID of the deleted item, e.g. ``"msg_abc123"``.
+    :param object: Fixed resource type, always
+        ``"conversation.item.deleted"``.
+    :param deleted: Always ``True``.
+    :param conversation_id: ID of the owning conversation,
+        e.g. ``"conv_abc123"``.
+    """
+
+    id: str
+    object: str = "conversation.item.deleted"
+    deleted: bool = True
+    conversation_id: str
 
 
 class ConversationRef(BaseModel):

--- a/agent_plane/stores/conversation_store/__init__.py
+++ b/agent_plane/stores/conversation_store/__init__.py
@@ -47,6 +47,7 @@ class ConversationStore(ABC):
         self,
         kind: str = "default",
         title: str | None = None,
+        metadata: dict[str, str] | None = None,
         parent_conversation_id: str | None = None,
     ) -> Conversation:
         """
@@ -60,6 +61,8 @@ class ConversationStore(ABC):
             store ``"<type>:<name>"`` so the partial unique index
             can enforce ``(parent_conversation_id, title)``
             uniqueness within a parent.
+        :param metadata: Optional key-value map of up to 16
+            pairs (keys ≤64 chars, values ≤512 chars).
         :param parent_conversation_id: Phase 4 — for child
             sub-agent conversations, the owning parent's id.
             ``None`` for top-level conversations.
@@ -239,8 +242,41 @@ class ConversationStore(ABC):
         ...
 
     @abstractmethod
+    def get_item(
+        self, conversation_id: str, item_id: str
+    ) -> ConversationItem | None:
+        """
+        Retrieve a single item from a conversation by ID.
+
+        :param conversation_id: Unique conversation identifier,
+            e.g. ``"conv_abc123"``.
+        :param item_id: Unique item identifier,
+            e.g. ``"msg_abc123"``.
+        :returns: The :class:`ConversationItem` if found and
+            belongs to the given conversation, otherwise ``None``.
+        """
+        ...
+
+    @abstractmethod
+    def delete_item(self, conversation_id: str, item_id: str) -> bool:
+        """
+        Delete a single item from a conversation.
+
+        :param conversation_id: Unique conversation identifier,
+            e.g. ``"conv_abc123"``.
+        :param item_id: Unique item identifier to delete,
+            e.g. ``"msg_abc123"``.
+        :returns: ``True`` if the item existed and was deleted,
+            ``False`` if no matching item was found.
+        """
+        ...
+
+    @abstractmethod
     def update_conversation(
-        self, conversation_id: str, title: str | None = None
+        self,
+        conversation_id: str,
+        title: str | None = None,
+        metadata: dict[str, str] | None = None,
     ) -> Conversation | None:
         """
         Update mutable fields on a conversation.
@@ -249,6 +285,8 @@ class ConversationStore(ABC):
             e.g. ``"conv_abc123"``.
         :param title: New title for the conversation, or ``None``
             to leave unchanged.
+        :param metadata: New metadata map to replace the existing
+            one, or ``None`` to leave unchanged.
         :returns: The updated :class:`Conversation`, or ``None``
             if the conversation does not exist.
         """

--- a/agent_plane/stores/conversation_store/sqlalchemy_store.py
+++ b/agent_plane/stores/conversation_store/sqlalchemy_store.py
@@ -42,6 +42,7 @@ def _to_conversation(row: SqlConversation) -> Conversation:
         created_at=row.created_at,
         updated_at=row.updated_at,
         title=row.title,
+        metadata=row.metadata_,
         kind=row.kind,
         parent_conversation_id=row.parent_conversation_id,
     )
@@ -119,6 +120,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         self,
         kind: str = "default",
         title: str | None = None,
+        metadata: dict[str, str] | None = None,
         parent_conversation_id: str | None = None,
     ) -> Conversation:
         """
@@ -131,6 +133,8 @@ class SqlAlchemyConversationStore(ConversationStore):
             store ``"<type>:<name>"`` so the partial unique
             index enforces ``(parent_conversation_id, title)``
             uniqueness within a parent.
+        :param metadata: Optional key-value map of up to 16
+            pairs (keys ≤64 chars, values ≤512 chars).
         :param parent_conversation_id: Phase 4 — id of the
             owning parent conversation. ``None`` for top-level.
         :returns: The newly created :class:`Conversation`.
@@ -148,6 +152,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             created_at=now,
             updated_at=now,
             title=title,
+            metadata_=metadata,
             kind=kind,
             parent_conversation_id=parent_conversation_id,
         )
@@ -568,8 +573,49 @@ class SqlAlchemyConversationStore(ConversationStore):
             id_cmp = SqlConversation.id > cursor_id if is_desc else SqlConversation.id < cursor_id
         return stmt.where(or_(ts_cmp, and_(sort_col == sub, id_cmp)))
 
+    def get_item(
+        self, conversation_id: str, item_id: str
+    ) -> ConversationItem | None:
+        """
+        Retrieve a single item by ID, scoped to the given conversation.
+
+        :param conversation_id: Unique conversation identifier,
+            e.g. ``"conv_abc123"``.
+        :param item_id: Unique item identifier,
+            e.g. ``"msg_abc123"``.
+        :returns: The :class:`ConversationItem` if found and
+            owned by the conversation, otherwise ``None``.
+        """
+        with self._session() as session:
+            row = session.get(SqlConversationItem, item_id)
+            if row is None or row.conversation_id != conversation_id:
+                return None
+            return _to_item(row)
+
+    def delete_item(self, conversation_id: str, item_id: str) -> bool:
+        """
+        Delete a single item from the given conversation.
+
+        :param conversation_id: Unique conversation identifier,
+            e.g. ``"conv_abc123"``.
+        :param item_id: Unique item identifier to delete,
+            e.g. ``"msg_abc123"``.
+        :returns: ``True`` if the item existed and was deleted,
+            ``False`` if the item was not found or does not
+            belong to the given conversation.
+        """
+        with self._session() as session:
+            row = session.get(SqlConversationItem, item_id)
+            if row is None or row.conversation_id != conversation_id:
+                return False
+            session.delete(row)
+            return True
+
     def update_conversation(
-        self, conversation_id: str, title: str | None = None
+        self,
+        conversation_id: str,
+        title: str | None = None,
+        metadata: dict[str, str] | None = None,
     ) -> Conversation | None:
         """
         Update mutable fields on a conversation.
@@ -577,8 +623,9 @@ class SqlAlchemyConversationStore(ConversationStore):
         :param conversation_id: Unique conversation identifier,
             e.g. ``"conv_abc123"``.
         :param title: New title, or ``None`` to leave unchanged.
-            When provided, ``updated_at`` is bumped to the
-            current epoch time.
+        :param metadata: New metadata map to replace the existing
+            one, or ``None`` to leave unchanged. When provided,
+            ``updated_at`` is bumped to the current epoch time.
         :returns: The updated :class:`Conversation`, or ``None``
             if the conversation does not exist.
         """
@@ -588,6 +635,9 @@ class SqlAlchemyConversationStore(ConversationStore):
                 return None
             if title is not None:
                 row.title = title
+                row.updated_at = now_epoch()
+            if metadata is not None:
+                row.metadata_ = metadata
                 row.updated_at = now_epoch()
             return _to_conversation(row)
 


### PR DESCRIPTION
## Summary

This PR aligns agent-plane's conversations API with two reference designs:
- **[Databricks Conversations Service Design](https://docs.google.com/document/d/1-CJI9Ia2y5Fy3ETHQkMgXq07W7q_sLRehPAYm8qwQvE/)** (Ann Zhang)
- **[OpenAI Conversations API](https://platform.openai.com/docs/api-reference/conversations)**

### Changes

**New endpoints:**
- `POST /v1/conversations` — explicit conversation creation (previously only auto-created)
- `POST /v1/conversations/{id}` — OpenAI-compat update alias (PATCH stays primary)
- `GET /v1/conversations/{id}/items/{item_id}` — single item retrieval
- `DELETE /v1/conversations/{id}/items/{item_id}` — single item deletion

**New field:**
- `metadata: dict[str, str] | null` on `ConversationObject` — up to 16 KV pairs, propagated through entity, DB, and store layers

**DB:** New Alembic migration adds `metadata` JSON column to the `conversations` table.

---

## API divergences worth discussing

### Conversations

| Feature | OpenAI / Databricks spec | agent-plane (this PR) |
|---|---|---|
| Update method | `POST /conversations/{id}` | `PATCH` (primary) + `POST` alias |
| Pagination | `page_token` / `next_page_token` | cursor-based `after` / `before` |
| `title` | not exposed externally | exposed (agent-plane extension) |
| `updated_at` | not in OpenAI spec | exposed (agent-plane extension) |
| Item creation | `POST /conversations/{id}/items` | not yet implemented (requires making `response_id` optional) |

### Agent Management

The [Universe Supervisor Agent CRUDL API](https://github.com/databricks/universe/blob/main/tiles/api/proto/supervisor_agents.proto) (`/api/2.1/supervisor-agents`) has significant architectural differences from agent-plane's `/api/agents`:

| Feature | Universe SupervisorAgent | agent-plane Agent |
|---|---|---|
| Create | JSON body with inline config | Bundle upload (`.tar.gz`) |
| ID format | Resource name `supervisor-agents/{id}` | Opaque `ag_*` prefix |
| Human name | `display_name` (required) | `name` (from bundle spec) |
| Tools | Separate CRUDL sub-resource | Embedded in bundle |
| Instructions | First-class field | Inside bundle `config.yaml` |
| Pagination | `page_token` / `next_page_token` | Cursor-based `after` / `before` |

These are architecturally different (declarative config vs bundle deploy). The most actionable alignment would be: agreeing on field names for the agent *response* object so a common SDK can work with both. Thoughts?

## Test plan
- [x] `tests/stores/test_conversation_store.py` — 38 tests, all passing
- [ ] Manual TUI verification (requires API key + running server)

This pull request was AI-assisted by Isaac.